### PR TITLE
fix libgit initialization

### DIFF
--- a/slcp.c
+++ b/slcp.c
@@ -100,6 +100,7 @@ int main(int argc, char* argv[])
 	if(argc > 1) termwidth = atoi(argv[1]);
 
 	/* init git repo */
+	git_libgit2_init();
 	if(!git_repository_discover(&tmpgitdb, ".", 0, NULL)
 	&& git_repository_open(&git_repo, tmpgitdb.ptr))
 	{


### PR DESCRIPTION
Without initializing libgit, slcp segfaults on armv7 with musl libc.

```
#0  __pthread_getspecific (k=0) at src/thread/pthread_getspecific.c:8
#1  0x76f1e934 in git__global_state () at /builddir/libgit2-0.22.3/src/global.c:328
#2  0x76ee6b0c in set_error (string=0x76e57930 "Could not find repository from '.'", error_class=6) at /builddir/libgit2-0.22.3/src/errors.c:23
#3  giterr_set (error_class=error_class@entry=6, string=0x76f463e8 "Could not find repository from '%s'") at /builddir/libgit2-0.22.3/src/error
#4  0x76f1a464 in find_repo (repo_path=repo_path@entry=0x7efff790, parent_path=parent_path@entry=0x0, start_path=0x76f410f4 "objects/", start_p
    flags=flags@entry=0, ceiling_dirs=ceiling_dirs@entry=0x0) at /builddir/libgit2-0.22.3/src/repository.c:402
#5  0x76f1aa7c in git_repository_discover (out=0x7efff790, start_path=0x54aabe9c ".", across_fs=<optimized out>, ceiling_dirs=0x0)
    at /builddir/libgit2-0.22.3/src/repository.c:515
#6  0x54aab0a4 in main (argc=1, argv=0x7efff7d4) at slcp.c:103
```
